### PR TITLE
Remove useless build warning

### DIFF
--- a/build/build_android_stubs.mk
+++ b/build/build_android_stubs.mk
@@ -40,7 +40,6 @@ $(full_target): PRIVATE_ERRORPRONE_FLAGS :=
 endif
 
 my_use_metalava := $(filter metalava%,$(sdk_stub_name))
-$(warning $(sdk_stub_name) $(my_use_metalava))
 
 ifdef my_use_metalava
 $(full_target): $(HOST_OUT_JAVA_LIBRARIES)/stub-annotations$(COMMON_JAVA_PACKAGE_SUFFIX)


### PR DESCRIPTION
* Avoids spam of the following messages on every single build:

  development/build/build_android_stubs.mk:43: warning: android_stubs_current
  development/build/build_android_stubs.mk:43: warning: metalava_android_stubs_current metalava_android_stubs_current
  development/build/build_android_stubs.mk:43: warning: android_system_stubs_current
  development/build/build_android_stubs.mk:43: warning: android_test_stubs_current
  development/build/build_android_stubs.mk:43: warning: metalava_android_system_stubs_current metalava_android_system_stubs_current
  development/build/build_android_stubs.mk:43: warning: metalava_android_test_stubs_current metalava_android_test_stubs_current

Change-Id: I5c96cc7334a3d04a4af85a6f737bb42b0d8ba41c