### PR TITLE
make-key: Enforce PBEv1 password-protected signing keys

### DIFF
--- a/tools/make_key
+++ b/tools/make_key
@@ -69,7 +69,7 @@ if [ "${password}" == "" ]; then
 else
   echo "creating ${1}.pk8 with password [${password}]"
   export password
-  openssl pkcs8 -in ${one} -topk8 -outform DER -out $1.pk8 \
+  openssl pkcs8 -in ${one} -topk8 -v1 PBE-SHA1-3DES -outform DER -out $1.pk8 \
     -passout env:password
   unset password
 fi


### PR DESCRIPTION
The bug https://bugs.openjdk.java.net/browse/JDK-8076999 prevents
the usage of PBESv2 key encryption schemes enforced by recent
OpenSSL versions.

So we enforce the PBE-SHA1-3DES scheme as recommended
in https://pthree.org/2013/05/27/strengthen-your-private-encrypted-ssh-keys/

Change-Id: I43239d4da1512d08563847db57af74146f8f66ea
Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>