### PR TITLE
development: Ship a 64-bit libc++.dylib in platform-tools

### DIFF
--- a/build/sdk-darwin-x86.atree
+++ b/build/sdk-darwin-x86.atree
@@ -18,7 +18,7 @@
 # Platform Tools Component
 ##############################################################################
 
-lib/libc++.dylib                                      strip platform-tools/lib/libc++.dylib
+lib64/libc++.dylib                                      strip platform-tools/lib64/libc++.dylib
 
 ##############################################################################
 # Build Tools Component


### PR DESCRIPTION
* The existing tools in platform-tools that link against
  libc++.dylib ended up loading the system version, not
  this one, due to the 32/64-bit mis-match.

Test: m sdk
Change-Id: Ibc985fe7a30e05052e728ad3ce4fd9e866476827